### PR TITLE
Support for Raspbery 2B boards 

### DIFF
--- a/asf.sh
+++ b/asf.sh
@@ -117,7 +117,7 @@ arch_check() {
         x86_64)
             ARCH=x64
             ;;
-        arm)
+        arm|armv7l)
             ARCH=arm
             ;;
         aarch64)

--- a/asf.sh
+++ b/asf.sh
@@ -95,7 +95,7 @@ os_check() {
     info_message "Checking OS..."
 
     # Check if running GNU/Linux type OS
-    if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    case $OSTYPE in linux-gnu*)
         # Check if they are using systemd init
         if [[ -d '/run/systemd/system' ]]; then
             ok_message "OS supported!"
@@ -105,10 +105,12 @@ os_check() {
             "If you know how to send a pull request for this, please do!"
             exit 1
         fi
-    else
+        ;;
+    *)
+    
         error_message "OS type not found. If you're running GNU/Linux, please report this on GitHub!"
         exit 1
-    fi
+    esac
 }
 
 arch_check() {


### PR DESCRIPTION
With this pull request, this script should now work on 2B boards, by adding the `armv7l` architecture. Also, for this boards using Raspbian, `$OSTYPE` returns `linux-gnueabihf`, so I had to change a `if` to `case in` on line 98 to be able to detect if `$OSTYPE` starts with `linux-gnu`.